### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 **Control your TrueNAS system using natural language through Claude Desktop**
 
+<a href="https://glama.ai/mcp/servers/@vespo92/TrueNasCoreMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vespo92/TrueNasCoreMCP/badge" alt="TrueNAS Core Server MCP server" />
+</a>
+
 [Features](#features) • [Quick Start](#quick-start) • [Installation](#installation) • [Documentation](#documentation) • [Examples](#examples)
 
 </div>


### PR DESCRIPTION
This PR adds a badge for the [TrueNAS Core MCP Server](https://glama.ai/mcp/servers/@vespo92/TrueNasCoreMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@vespo92/TrueNasCoreMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vespo92/TrueNasCoreMCP/badge" alt="TrueNAS Core Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.