### PR TITLE
feat: Add pagination and reduce token usage in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,74 @@ asyncio.run(main())
 - `test_connection` - Verify API connectivity
 - `get_server_stats` - Server statistics
 
+## 📄 Pagination and Response Control
+
+All list operations support pagination to reduce token usage when working with LLM clients. Get operations support optional raw API response inclusion for debugging.
+
+### Pagination Parameters
+
+All `list_*` tools support these parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | 100 | Maximum items to return (max: 500) |
+| `offset` | integer | 0 | Number of items to skip |
+
+**Response format:**
+```json
+{
+  "success": true,
+  "items": [...],
+  "metadata": { ... },
+  "pagination": {
+    "total": 250,
+    "limit": 100,
+    "offset": 0,
+    "returned": 100,
+    "has_more": true
+  }
+}
+```
+
+**Usage examples:**
+```
+"List the first 10 datasets"          → limit=10
+"Show users 50-100"                   → limit=50, offset=50
+"Get all SMB shares (up to 500)"      → limit=500
+```
+
+### Include Raw API Response
+
+Get operations for apps, instances, and VMs support the `include_raw` parameter:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `include_raw` | boolean | false | Include full API response for debugging |
+
+**When to use `include_raw=true`:**
+- Debugging API response structure
+- Accessing fields not included in the formatted response
+- Troubleshooting integration issues
+
+**Tools supporting `include_raw`:**
+- `get_app` - App details
+- `get_instance` - Incus instance details
+- `get_legacy_vm` - Legacy VM details
+
+### Dataset Response Control
+
+The `list_datasets` and `get_dataset` tools support an additional parameter:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `include_children` | boolean | true | Include child datasets (can reduce payload significantly) |
+
+**Usage:**
+```
+"List only top-level datasets"        → include_children=false
+"Get tank dataset without children"   → include_children=false
+```
+
 ## 🏗️ Architecture
 
 ```


### PR DESCRIPTION
## Summary

This PR addresses a significant issue with token consumption when using the TrueNAS MCP server with LLM clients. Initial list operations were consuming 40k+ tokens due to:
1. No pagination - list operations returned all items regardless of count
2. Raw API responses included by default - duplicating data in get operations
3. Recursive child datasets always included - creating large nested payloads

### Changes

**Pagination Support (all list operations):**
- Added `limit` parameter (default: 100, max: 500)
- Added `offset` parameter for pagination
- Returns `pagination` metadata: `{total, limit, offset, returned, has_more}`

**Affected tools:**
- `list_pools`, `list_datasets`
- `list_snapshots`, `list_snapshot_tasks`
- `list_apps`, `list_instances`, `list_legacy_vms`
- `list_smb_shares`, `list_nfs_exports`, `list_iscsi_targets`
- `list_users`

**Opt-in Raw Response:**
- `get_app`, `get_instance`, `get_legacy_vm` now exclude `raw` field by default
- Added `include_raw` parameter (default: false) to restore if needed for debugging

**Dataset Control:**
- Added `include_children` parameter to `list_datasets` and `get_dataset` (default: true)
- Can be set to false to reduce payload for large dataset hierarchies

### ⚠️ Breaking Changes

This PR introduces intentional breaking changes to reduce token usage:

1. **`get_app`, `get_instance`, `get_legacy_vm`**: No longer include `raw` field by default
   - **Migration:** Use `include_raw=true` to restore previous behavior

2. **All list operations**: Now paginated by default (limit=100)
   - **Migration:** Use `limit=500` for larger result sets, or implement pagination

### Rationale

When using this MCP server with Claude or other LLM clients, excessive response sizes directly impact:
- Context window consumption
- Response latency
- Cost per interaction

With environments containing hundreds of snapshots, datasets, or users, the previous behavior was impractical for LLM use cases. These changes make the server significantly more efficient while maintaining full functionality through opt-in parameters.

### Documentation

Updated README.md with a new "Pagination and Response Control" section documenting:
- Pagination parameters and response format
- `include_raw` usage guidelines
- `include_children` for datasets

## Test plan
- [ ] Verify list operations return paginated results with metadata
- [ ] Test `limit` and `offset` parameters work correctly
- [ ] Confirm `include_raw=true` returns full API response
- [ ] Test `include_children=false` excludes child datasets
- [ ] Verify backwards compatibility for callers not using new parameters