### PR TITLE
fix: TRUENAS_VERIFY_SSL=false silently ignored when custom transport is used

### DIFF
--- a/truenas_mcp_server/client/http_client.py
+++ b/truenas_mcp_server/client/http_client.py
@@ -130,15 +130,20 @@ class TrueNASClient:
     async def connect(self):
         """Initialize the HTTP client"""
         if self._client is None:
+            # verify must be passed to AsyncHTTPTransport directly; when a
+            # custom transport is supplied to AsyncClient, the client-level
+            # verify= parameter is ignored by httpx and SSL verification
+            # defaults to enabled regardless of the setting.
             transport = httpx.AsyncHTTPTransport(
                 retries=0,  # We handle retries ourselves
+                verify=self.settings.truenas_verify_ssl,
                 limits=httpx.Limits(
                     max_connections=self.settings.http_pool_connections,
                     max_keepalive_connections=self.settings.http_pool_maxsize,
                     keepalive_expiry=30.0
                 )
             )
-            
+
             self._client = httpx.AsyncClient(
                 base_url=self.settings.api_base_url,
                 headers=self.settings.headers,


### PR DESCRIPTION
## Problem

When `httpx.AsyncClient` is given a custom `AsyncHTTPTransport`, the `verify=` parameter on the client is **silently ignored** — SSL verification is determined entirely by the transport. This means `TRUENAS_VERIFY_SSL=false` (or `true`) had no effect, and every API call failed with `SSL: CERTIFICATE_VERIFY_FAILED` for users with self-signed certificates or a local CA.

Closes #9

## Fix

Pass `verify=self.settings.truenas_verify_ssl` to `AsyncHTTPTransport` directly:

```python
transport = httpx.AsyncHTTPTransport(
    retries=0,
    verify=self.settings.truenas_verify_ssl,  # was missing
    limits=httpx.Limits(...)
)
```

The `verify=` on `AsyncClient` is left in place so the intent remains clear if the transport is ever removed.

## Test

Before fix — with `TRUENAS_VERIFY_SSL=false`:
```
WARNING - Request failed (attempt 1/3): SSL: CERTIFICATE_VERIFY_FAILED
WARNING - Failed to detect TrueNAS variant: Connection failed after 3 attempts
```

After fix:
```
INFO - Detected TrueNAS SCALE (via /app endpoint): 25.10.1
INFO - Connected to TrueNAS SCALE version 25.10.1
INFO - TrueNAS MCP Server initialized successfully
```

## Notes

This is bug #3 from issue #9. Bugs #1 and #2 in that issue are already fixed in `main` (v4.1.0 source) but v4.1.0 has not been published to PyPI — publishing it would also fix those for end users.